### PR TITLE
Use SPDX 3.0 license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Theme and plugins for WikiMedia Foundation project",
   "keywords": [],
   "type": "wordpress-plugin",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/reaktivstudios/wmfoundation",
   "authors": [
     {


### PR DESCRIPTION
SPDX released version 3 of their license list (<https://spdx.org/licenses/>),
which changed the FSF licenses to explicitly end in -only or -or-later
instead of relying on an easy to miss + symbol.